### PR TITLE
Upgrade json-jwt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.0.0-p647
-  - 2.1.7
-  - 2.2.0
-  - 2.2.1
-  - 2.2.2
-  - 2.2.3
+  - 2.3.1
+  - 2.3.6
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 script:
   - bundle exec rake test

--- a/lib/rack/prx_auth/version.rb
+++ b/lib/rack/prx_auth/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class PrxAuth
-    VERSION = "0.0.9"
+    VERSION = "0.1.0"
   end
 end

--- a/lib/rack/prx_auth/version.rb
+++ b/lib/rack/prx_auth/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class PrxAuth
-    VERSION = "0.0.8"
+    VERSION = "0.0.9"
   end
 end

--- a/rack-prx_auth.gemspec
+++ b/rack-prx_auth.gemspec
@@ -18,11 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^test/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'coveralls', '~> 0'
 
   spec.add_dependency 'rack', '~> 1.5', '>= 1.5.2'
   spec.add_dependency 'json', '~> 1.8', '>= 1.8.1'
-  spec.add_dependency 'json-jwt', '~> 1.0', '>= 1.0.1'
+  spec.add_dependency 'json-jwt', '~> 1.9.4'
 end


### PR DESCRIPTION
Fixes [this exploit](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/json-jwt/CVE-2018-1000539.yml).  But requires ruby 2.3+.