### PR TITLE
Feat/fixup no method count for nil class

### DIFF
--- a/lib/rack/prx_auth.rb
+++ b/lib/rack/prx_auth.rb
@@ -43,6 +43,8 @@ module Rack
     end
 
     def decode_token(token)
+      return {} if token.nil?
+
       begin
         JSON::JWT.decode(token, :skip_verification)
       rescue JSON::JWT::InvalidFormat

--- a/test/rack/prx_auth_test.rb
+++ b/test/rack/prx_auth_test.rb
@@ -26,6 +26,11 @@ describe Rack::PrxAuth do
       prxauth.call(env.clone).must_equal env
     end
 
+    it 'does nothing if the token is nil' do
+      env = {"HTTP_AUTHORIZATION"=>"Bearer "}
+      prxauth.call(env).must_equal env
+    end
+
     it 'returns 401 if verification fails' do
       JSON::JWT.stub(:decode, claims) do
         prxauth.stub(:valid?, false) do
@@ -74,6 +79,12 @@ describe Rack::PrxAuth do
         Rack::PrxAuth.new(app, cert_location: :location)
         loc.must_equal :location
       end
+    end
+  end
+
+  describe '#decode_token' do
+    it 'should return an empty result for a nil token' do
+      prxauth.send(:decode_token, nil).must_equal({})
     end
   end
 end

--- a/test/rack/prx_auth_test.rb
+++ b/test/rack/prx_auth_test.rb
@@ -86,5 +86,13 @@ describe Rack::PrxAuth do
     it 'should return an empty result for a nil token' do
       prxauth.send(:decode_token, nil).must_equal({})
     end
+
+    it 'should return an empty result for an empty token' do
+      prxauth.send(:decode_token, {}).must_equal({})
+    end
+
+    it 'should return an empty result for a malformed token' do
+      prxauth.send(:decode_token, 'asdfsadfsad').must_equal({})
+    end
   end
 end


### PR DESCRIPTION
Fixes a class of errors that look like:
```
undefined method `count' for nil:NilClass
```

These errors show up in the logs when clients send a request with Authorization headers that are missing the token.  Something that looks like
```
Authorization: bearer 
```
 Splitting the header value results in a nil token which is passed to the `decode_token` method. This PR sets up a method guard against the nil token and returns an empty value.