### PR TITLE
Support wildcard resources for tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.o
 *.a
 mkmf.log
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rack-prx_auth.gemspec
 gemspec
-
-gem 'guard'
-gem 'guard-minitest'

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -34,6 +34,7 @@ module Rack
 
         authorized_for_resource?(WILDCARD_RESOURCE_NAME, scope)
       end
+      
       private
 
       def authorized_for_resource?(resource, scope=nil)

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -24,9 +24,13 @@ module Rack
       end
 
       def authorized?(resource, scope=nil)
-        return globally_authorized?(scope) if resource == WILDCARD_RESOURCE_NAME
-
-        authorized_for_resource?(resource, scope) || (scope.nil? ? false : globally_authorized?(scope))
+        if resource == WILDCARD_RESOURCE_NAME
+          globally_authorized?(scope)
+        elsif scope.nil?
+          authorized_for_resource?(resource, scope)
+        else
+          authorized_for_resource?(resource, scope) || globally_authorized?(scope)
+        end
       end
 
       def globally_authorized?(scope)

--- a/lib/rack/prx_auth/version.rb
+++ b/lib/rack/prx_auth/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class PrxAuth
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/rack-prx_auth.gemspec
+++ b/rack-prx_auth.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'coveralls', '~> 0'
+  spec.add_development_dependency 'guard'
+  spec.add_development_dependency 'guard-minitest'
 
   spec.add_dependency 'rack', '>= 1.5.2'
   spec.add_dependency 'json', '>= 1.8.1'


### PR DESCRIPTION
Adds one method, `globally_authorized?` and passes through to it when `authorized?` is called with a scope explicitly provided.

For a few reasons, I don't think it makes sense to ever ask if the token is globally authorized without also naming a scope, so we don't allow that currently. Obviously, that can be changed, but I'd like to hear more about that use case.

I currently treat `0` as a wildcard if the preferred wildcard token, `*`, is not present. That's because it will avoid requiring a deploy to id before this starts working. Happy to pull that out, as I would expect we want to do so at some point anyway.