### PR TITLE
Treat aur values as lists of scopes

### DIFF
--- a/lib/prx_auth.rb
+++ b/lib/prx_auth.rb
@@ -1,5 +1,6 @@
 require 'prx_auth/scope_list'
-require 'rack/prx_auth'
+require 'prx_auth/resource_map'
+require 'rack/prx_auth/version'
 
 module PrxAuth
   VERSION = Rack::PrxAuth::VERSION

--- a/lib/prx_auth.rb
+++ b/lib/prx_auth.rb
@@ -1,0 +1,6 @@
+require 'prx_auth/scope_list'
+require 'rack/prx_auth'
+
+module PrxAuth
+  VERSION = Rack::PrxAuth::VERSION
+end

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -8,16 +8,17 @@ module PrxAuth
       end]
     end
 
-    def contains?(resource, scope=nil)
+    def contains?(resource, namespace=nil, scope=nil)
       mapped_resource = @map[resource.to_s]
+
       if mapped_resource == wildcard_resource
-        raise ArgumentError if scope.nil?
+        raise ArgumentError if namespace.nil?
       
-        mapped_resource.contains?(scope)
-      elsif mapped_resource && !scope.nil?
-        mapped_resource.contains?(scope) || wildcard_resource.contains?(scope)
-      elsif !scope.nil?
-        wildcard_resource.contains?(scope)
+        mapped_resource.contains?(namespace, scope)
+      elsif mapped_resource && !namespace.nil?
+        mapped_resource.contains?(namespace, scope) || wildcard_resource.contains?(namespace, scope)
+      elsif !namespace.nil?
+        wildcard_resource.contains?(namespace, scope)
       else
         !!mapped_resource
       end

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -1,4 +1,32 @@
 module PrxAuth
   class ResourceMap
+    WILDCARD_KEY = '*'
+
+    def initialize(mapped_values)
+      @map = Hash[mapped_values.map do |(key, values)|
+        [key, ScopeList.new(values)]
+      end]
+    end
+
+    def contains?(resource, scope=nil)
+      mapped_resource = @map[resource.to_s]
+      if mapped_resource == wildcard_resource
+        raise ArgumentError if scope.nil?
+      
+        mapped_resource.contains?(scope)
+      elsif mapped_resource && !scope.nil?
+        mapped_resource.contains?(scope) || wildcard_resource.contains?(scope)
+      elsif !scope.nil?
+        wildcard_resource.contains?(scope)
+      else
+        !!mapped_resource
+      end
+    end
+
+    private
+
+    def wildcard_resource
+      @wildcard_resource ||= @map[WILDCARD_KEY] || ScopeList.new('')
+    end
   end
 end

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -1,0 +1,4 @@
+module PrxAuth
+  class ResourceMap
+  end
+end

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -24,6 +24,12 @@ module PrxAuth
       end
     end
 
+    def freeze
+      @map.freeze
+      wildcard_resource.freeze
+      self
+    end
+
     private
 
     def wildcard_resource

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -3,37 +3,47 @@ module PrxAuth
     WILDCARD_KEY = '*'
 
     def initialize(mapped_values)
-      @map = Hash[mapped_values.map do |(key, values)|
+      input = mapped_values.clone
+      @wildcard = ScopeList.new(input.delete(WILDCARD_KEY)||'')
+      @map = Hash[input.map do |(key, values)|
         [key, ScopeList.new(values)]
       end]
     end
 
     def contains?(resource, namespace=nil, scope=nil)
-      mapped_resource = @map[resource.to_s]
+      resource = resource.to_s
 
-      if mapped_resource == wildcard_resource
+      if resource == WILDCARD_KEY
         raise ArgumentError if namespace.nil?
       
-        mapped_resource.contains?(namespace, scope)
-      elsif mapped_resource && !namespace.nil?
-        mapped_resource.contains?(namespace, scope) || wildcard_resource.contains?(namespace, scope)
-      elsif !namespace.nil?
-        wildcard_resource.contains?(namespace, scope)
+        @wildcard.contains?(namespace, scope)
       else
-        !!mapped_resource
+        mapped_resource = @map[resource]
+        
+        if mapped_resource && !namespace.nil?
+          mapped_resource.contains?(namespace, scope) || @wildcard.contains?(namespace, scope)
+        elsif !namespace.nil?
+          @wildcard.contains?(namespace, scope)
+        else
+          !!mapped_resource
+        end
       end
     end
 
     def freeze
       @map.freeze
-      wildcard_resource.freeze
+      @wildcard.freeze
       self
     end
 
-    private
-
-    def wildcard_resource
-      @wildcard_resource ||= @map[WILDCARD_KEY] || ScopeList.new('')
+    def resources(namespace=nil, scope=nil)
+      if namespace.nil?
+        @map.keys
+      else
+        @map.select do |name, list|
+          list.contains?(namespace, scope)
+        end.map(&:first)
+      end
     end
   end
 end

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -1,4 +1,53 @@
 module PrxAuth
   class ScopeList
+    SCOPE_SEPARATOR = ' '
+    NAMESPACE_SEPARATOR = ':'
+    NO_NAMESPACE = :_
+
+    def initialize(list)
+      @string = list
+    end
+
+    def contains?(namespace, scope=nil)
+      scope, namespace = namespace, NO_NAMESPACE if scope.nil?
+
+      if namespace == NO_NAMESPACE
+        map[namespace].include?(symbolize(scope))
+      else
+        symbolized_scope = symbolize(scope)
+        map[namespace].include?(symbolized_scope) || map[NO_NAMESPACE].include?(symbolized_scope)
+      end
+    end
+
+    private
+
+    def map
+      @parsed_map ||= empty_map.tap do |map|
+        @string.split(SCOPE_SEPARATOR).each do |value|
+          next if value.length < 1
+
+          parts = value.split(NAMESPACE_SEPARATOR, 2)
+          if parts.length == 2
+            map[symbolize(parts[0])] << symbolize(parts[1])
+          else
+            map[NO_NAMESPACE] << symbolize(parts[0])
+          end
+        end
+      end
+    end
+
+    def empty_map
+      @empty_map ||= Hash.new do |hash, key|
+        hash[key] = []
+      end
+    end
+
+    def symbolize(value)
+      case value
+      when Symbol then value
+      when String then value.downcase.gsub('-', '_').intern
+      else symbolize value.to_s
+      end
+    end
   end
 end

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -1,0 +1,4 @@
+module PrxAuth
+  class ScopeList
+  end
+end

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -15,7 +15,7 @@ module PrxAuth
         map[namespace].include?(symbolize(scope))
       else
         symbolized_scope = symbolize(scope)
-        map[namespace].include?(symbolized_scope) || map[NO_NAMESPACE].include?(symbolized_scope)
+        map[symbolize(namespace)].include?(symbolized_scope) || map[NO_NAMESPACE].include?(symbolized_scope)
       end
     end
 

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -19,6 +19,11 @@ module PrxAuth
       end
     end
 
+    def freeze
+      @string.freeze
+      self
+    end
+
     private
 
     def map

--- a/lib/rack/prx_auth.rb
+++ b/lib/rack/prx_auth.rb
@@ -2,6 +2,7 @@ require 'json/jwt'
 require 'rack/prx_auth/version'
 require 'rack/prx_auth/certificate'
 require 'rack/prx_auth/token_data'
+require 'prx_auth'
 
 module Rack
   class PrxAuth

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -3,7 +3,7 @@ require 'prx_auth/resource_map'
 module Rack
   class PrxAuth
     class TokenData
-      attr_reader :attributes, :authorized_resources, :scopes
+      attr_reader :scopes
 
       def initialize(attrs = {})
         @attributes = attrs
@@ -15,6 +15,10 @@ module Rack
         else
           @scopes = [].freeze
         end
+      end
+
+      def resources(namespace=nil, scope=nil)
+        @authorized_resources.resources(namespace, scope)
       end
 
       def user_id

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -1,17 +1,15 @@
+require 'prx_auth/resource_map'
+
 module Rack
   class PrxAuth
     class TokenData
-      WILDCARD_RESOURCE_NAME = '*'
-
       attr_reader :attributes, :authorized_resources, :scopes
 
       def initialize(attrs = {})
         @attributes = attrs
-        if attrs['aur']
-          @authorized_resources = unpack_aur(attrs['aur']).freeze
-        else
-          @authorized_resources = {}.freeze
-        end
+
+        @authorized_resources = ::PrxAuth::ResourceMap.new(unpack_aur(attrs['aur'])).freeze
+        
         if attrs['scope']
           @scopes = attrs['scope'].split(' ').freeze
         else
@@ -23,31 +21,19 @@ module Rack
         @attributes['sub']
       end
 
-      def authorized?(resource, scope=nil)
-        if resource == WILDCARD_RESOURCE_NAME
-          globally_authorized?(scope)
-        elsif scope.nil?
-          authorized_for_resource?(resource, scope)
-        else
-          authorized_for_resource?(resource, scope) || globally_authorized?(scope)
-        end
+      def authorized?(resource, namespace=nil, scope=nil)
+        @authorized_resources.contains?(resource, namespace, scope)
       end
 
-      def globally_authorized?(scope)
-        raise ArgumentError if scope.nil?
-
-        authorized_for_resource?(WILDCARD_RESOURCE_NAME, scope)
+      def globally_authorized?(namespace, scope=nil)
+        authorized?(::PrxAuth::ResourceMap::WILDCARD_KEY, namespace, scope)
       end
       
       private
 
-      def authorized_for_resource?(resource, scope=nil)
-        if auth = authorized_resources[resource.to_s]
-          scope.nil? || (scopes + auth.split(' ')).include?(scope.to_s)
-        end
-      end
-
       def unpack_aur(aur)
+        return {} if aur.nil?
+
         aur.clone.tap do |result|
           unless result['$'].nil?
             result.delete('$').each do |role, resources|

--- a/lib/rack/prx_auth/token_data.rb
+++ b/lib/rack/prx_auth/token_data.rb
@@ -56,9 +56,6 @@ module Rack
               end
             end
           end
-          if result[WILDCARD_RESOURCE_NAME].nil? && result['0']
-            result[WILDCARD_RESOURCE_NAME] = result.delete('0')
-          end
         end
       end
     end

--- a/lib/rack/prx_auth/version.rb
+++ b/lib/rack/prx_auth/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class PrxAuth
-    VERSION = "0.3.0"
+    VERSION = "1.0.0"
   end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -1,5 +1,57 @@
 require 'test_helper'
 
 describe PrxAuth::ResourceMap do
-  
+  let(:map) { PrxAuth::ResourceMap.new(resources) }
+  let(:resources) { {'123' => 'admin one two three', '456' => 'member four five six' } }
+
+  describe '#authorized?' do
+    it 'contains scopes in list' do
+      assert map.contains?(123, :admin)
+    end
+
+    it 'does not include across aur limits' do
+      assert !map.contains?(123, :member)
+    end
+
+    it 'does not require a scope' do
+      assert map.contains?(123)
+    end
+
+    it 'does not match if it hasnt seen the resource' do
+      assert !map.contains?(789)
+    end
+
+    describe 'with wildcard resource' do
+      let(:resources) do
+        {
+          '*' => 'peek',
+          '123' => 'admin one two three',
+          '456' => 'member four five six'
+        }
+      end
+
+      it 'applies wildcard lists to queries with no matching value' do
+        assert map.contains?(789, :peek)
+      end
+
+      it 'does not scan unscoped for wildcard resources' do
+        assert !map.contains?(789)
+      end
+
+      it 'allows querying by wildcard resource directly' do
+        assert map.contains?('*', :peek)
+        assert !map.contains?('*', :admin)
+      end
+
+      it 'treats wildcard lists as additive to other explicit ones' do
+        assert map.contains?(123, :peek)
+      end
+
+      it 'refuses to run against wildcard with no scope' do
+        assert_raises ArgumentError do
+          map.contains?('*')
+        end
+      end
+    end
+  end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe PrxAuth::ResourceMap do
   let(:map) { PrxAuth::ResourceMap.new(resources) }
-  let(:resources) { {'123' => 'admin one two three', '456' => 'member four five six' } }
+  let(:resources) { {'123' => 'admin one two three ns1:namespaced', '456' => 'member four five six' } }
 
   describe '#authorized?' do
     it 'contains scopes in list' do
@@ -19,6 +19,10 @@ describe PrxAuth::ResourceMap do
 
     it 'does not match if it hasnt seen the resource' do
       assert !map.contains?(789)
+    end
+
+    it 'works with namespaced scopes' do
+      assert map.contains?(123, :ns1, :namespaced)
     end
 
     describe 'with wildcard resource' do

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 describe PrxAuth::ResourceMap do
-  let(:map) { PrxAuth::ResourceMap.new(resources) }
-  let(:resources) { {'123' => 'admin one two three ns1:namespaced', '456' => 'member four five six' } }
+  let(:map) { PrxAuth::ResourceMap.new(input) }
+  let(:input) { {'123' => 'admin one two three ns1:namespaced', '456' => 'member four five six' } }
 
   describe '#authorized?' do
     it 'contains scopes in list' do
@@ -26,7 +26,7 @@ describe PrxAuth::ResourceMap do
     end
 
     describe 'with wildcard resource' do
-      let(:resources) do
+      let(:input) do
         {
           '*' => 'peek',
           '123' => 'admin one two three',
@@ -56,6 +56,43 @@ describe PrxAuth::ResourceMap do
           map.contains?('*')
         end
       end
+    end
+  end
+
+  describe '#resources' do
+    let (:input) do
+      {
+        '*' => 'read wildcard',
+        '123' => 'read write buy',
+        '456' => 'read ns1:buy'
+      }
+    end
+
+    let (:resources) { map.resources }
+
+    it 'returns resource ids' do
+      assert resources.include?('123')
+      assert resources.include?('456')
+    end
+
+    it 'excludes wildcard values' do
+      assert !resources.include?('*')
+    end
+
+    it 'filters for scope' do
+      resources = map.resources(:write)
+      assert resources.include?('123')
+      assert !resources.include?('456')
+      assert !resources.include?('*')
+    end
+
+    it 'works with namespaces' do
+      resources = map.resources(:ns1, :buy)
+      assert resources.include?('123')
+      assert resources.include?('456')
+
+      resources = map.resources(:buy)
+      assert !resources.include?('456')
     end
   end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+describe PrxAuth::ResourceMap do
+  
+end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -1,6 +1,41 @@
 require 'test_helper'
 
 describe PrxAuth::ScopeList do
+  let (:scopes) { 'read write sell  top-up' }
+  let (:list) { PrxAuth::ScopeList.new(scopes) }
+
+  it 'looks up successfully for a given scope' do
+    assert list.contains?('write')
+  end
   
-  
+  it 'scans for symbols' do
+    assert list.contains?(:read)
+  end
+
+  it 'handles hyphen to underscore conversions' do
+    assert list.contains?(:top_up)
+  end
+
+  it 'fails for contents not in the list' do
+    assert !list.contains?(:buy)
+  end
+
+  describe 'with namespace' do
+    let (:scopes) { 'ns1:hello ns2:goodbye aloha' }
+    
+    it 'works for namespaced lookups' do
+      assert list.contains?(:ns1, :hello)
+    end
+
+    it 'fails when the wrong namespace is passed' do
+      assert !list.contains?(:ns1, :goodbye)
+    end
+
+    it 'looks up global scopes when namespaced fails' do
+      assert list.contains?(:ns1, :aloha)
+      assert list.contains?(:ns3, :aloha)
+    end
+
+  end
+
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -21,7 +21,7 @@ describe PrxAuth::ScopeList do
   end
 
   describe 'with namespace' do
-    let (:scopes) { 'ns1:hello ns2:goodbye aloha' }
+    let (:scopes) { 'ns1:hello ns2:goodbye aloha 1:23' }
     
     it 'works for namespaced lookups' do
       assert list.contains?(:ns1, :hello)
@@ -36,6 +36,9 @@ describe PrxAuth::ScopeList do
       assert list.contains?(:ns3, :aloha)
     end
 
+    it 'works with non-symbol namespaces' do
+      assert list.contains?(1, 23)
+    end
   end
 
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+describe PrxAuth::ScopeList do
+  
+  
+end

--- a/test/rack/prx_auth/token_data_test.rb
+++ b/test/rack/prx_auth/token_data_test.rb
@@ -82,25 +82,5 @@ describe Rack::PrxAuth::TokenData do
         end
       end
     end
-
-    describe 'wildcard fallback handling' do
-
-      describe 'with no primary wildcard present' do
-        let(:aur) { {'0' => 'peek', '123' => 'admin', '456' => 'member' } }
-
-        it 'applies fallback as a wildcard' do
-          assert token.authorized?(789, :peek)
-        end
-      end
-
-      describe 'with primary wildcard present' do
-        let(:aur) { {'*' => 'cook', '0' => 'peek', '123' => 'admin', '456' => 'member' } }
-
-        it 'does not apply the fallback as a wildcard' do
-          assert token.authorized?(789, :cook)
-          assert !token.authorized?(789, :peek)
-        end
-      end
-    end
   end
 end

--- a/test/rack/prx_auth_test.rb
+++ b/test/rack/prx_auth_test.rb
@@ -52,7 +52,6 @@ describe Rack::PrxAuth do
         prxauth.stub(:valid?, true) do
           prxauth.call(env)['prx.auth'].tap do |token|
             assert token.instance_of? Rack::PrxAuth::TokenData
-            assert token.attributes == claims
             assert token.user_id == claims['sub']
           end
         end

--- a/test/rack/prx_auth_test.rb
+++ b/test/rack/prx_auth_test.rb
@@ -11,30 +11,30 @@ describe Rack::PrxAuth do
     it 'does nothing if there is no authorization header' do
       env = {}
 
-      prxauth.call(env.clone).must_equal env
+      assert prxauth.call(env.clone) == env
     end
 
     it 'does nothing if the token is from another issuer' do
       claims['iss'] = 'auth.elsewhere.org'
 
       JSON::JWT.stub(:decode, claims) do
-        prxauth.call(env.clone).must_equal env
+        assert prxauth.call(env.clone) == env
       end
     end
 
     it 'does nothing if token is invalid' do
-      prxauth.call(env.clone).must_equal env
+      assert prxauth.call(env.clone) == env
     end
 
     it 'does nothing if the token is nil' do
-      env = {"HTTP_AUTHORIZATION"=>"Bearer "}
-      prxauth.call(env).must_equal env
+      env = { "HTTP_AUTHORIZATION" => "Bearer "}
+      assert prxauth.call(env) == env
     end
 
     it 'returns 401 if verification fails' do
       JSON::JWT.stub(:decode, claims) do
         prxauth.stub(:valid?, false) do
-          prxauth.call(env).must_equal Rack::PrxAuth::INVALID_TOKEN
+          assert prxauth.call(env) == Rack::PrxAuth::INVALID_TOKEN
         end
       end
     end
@@ -42,7 +42,7 @@ describe Rack::PrxAuth do
     it 'returns 401 if access token has expired' do
       JSON::JWT.stub(:decode, claims) do
         prxauth.stub(:expired?, true) do
-          prxauth.call(env).must_equal Rack::PrxAuth::INVALID_TOKEN
+          assert prxauth.call(env) == Rack::PrxAuth::INVALID_TOKEN
         end
       end
     end
@@ -51,9 +51,9 @@ describe Rack::PrxAuth do
       prxauth.stub(:decode_token, claims) do
         prxauth.stub(:valid?, true) do
           prxauth.call(env)['prx.auth'].tap do |token|
-            token.must_be_instance_of Rack::PrxAuth::TokenData
-            token.attributes.must_equal claims
-            token.user_id.must_equal claims['sub']
+            assert token.instance_of? Rack::PrxAuth::TokenData
+            assert token.attributes == claims
+            assert token.user_id == claims['sub']
           end
         end
       end
@@ -64,11 +64,11 @@ describe Rack::PrxAuth do
     it 'returns true if token is expired' do
       claims['iat'] = Time.now.to_i - 4000
 
-      prxauth.send(:expired?, claims).must_equal true
+      assert prxauth.send(:expired?, claims) == true
     end
 
     it 'returns false if it is valid' do
-      prxauth.send(:expired?, claims).must_equal false
+      assert prxauth.send(:expired?, claims) == false
     end
   end
 
@@ -77,22 +77,22 @@ describe Rack::PrxAuth do
       loc = nil
       Rack::PrxAuth::Certificate.stub(:new, Proc.new{|l| loc = l}) do
         Rack::PrxAuth.new(app, cert_location: :location)
-        loc.must_equal :location
+        assert loc == :location
       end
     end
   end
 
   describe '#decode_token' do
     it 'should return an empty result for a nil token' do
-      prxauth.send(:decode_token, nil).must_equal({})
+      assert prxauth.send(:decode_token, nil) == {}
     end
 
     it 'should return an empty result for an empty token' do
-      prxauth.send(:decode_token, {}).must_equal({})
+      assert prxauth.send(:decode_token, {}) == {}
     end
 
     it 'should return an empty result for a malformed token' do
-      prxauth.send(:decode_token, 'asdfsadfsad').must_equal({})
+      assert prxauth.send(:decode_token, 'asdfsadfsad') == {}
     end
   end
 end


### PR DESCRIPTION
Ok! So here we are.

This makes a few breaking changes, but the end result is pretty much summed up here:

https://github.com/PRX/rack-prx_auth/pull/19/files#diff-7c569a6167ee73eb7b1bb010dfcaf2a8R47

So, we now support lists of values in the `aur` hash instead of just a single value, and support namespaced scopes. We also no longer care about what is in `scope` (for now, since that is up in the air at the moment). Finally, I have started the process of moving utility classes up into the ::PrxAuth namespace, since it doesn't make sense for them to live under Rack:: forever.

I would advocate for changing this gem to PrxAuth and keeping the current separation between it and the -rails gem, since prx_auth-rails does some railtie magic but the Rack::PrxAuth stuff requires code to do anything.

I'm thinking that the Token is the level at which compression happens, and that's the case here, with the invert hash still living in the TokenData class. If the ScopeList and ResourceMap classes don't get involved in compression, that also saves us from accidentally making the mistake of putting wildcard scopes in a place that they can't be expanded by Token, which prevents a scenario where tokens are retroactively granted additional permissions because of a deploy.

I think there are still some major changes to make here in support of making a consistent library for compressing and decompressing new style tokens, but this should be feature complete for the purposes of fully-uncompressed tokens.

I'm also going to update the PrxAuth::Rails gem to automatically include namespaces on queries based on the application name, but remember that un-namespaced scopes in tokens are effectively treated as `*:scope`, so no extra code changes will be required once that is in place.

Onward!