### PR TITLE
Implement ScopeList and ResourceMap utilities

### DIFF
--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -38,6 +38,62 @@ module PrxAuth
       ResourceMap.new(condensed_map.merge(WILDCARD_KEY => condensed_wildcard))
     end
 
+    def +(other_map)
+      result = {}
+      (resources + other_map.resources + [WILDCARD_KEY]).uniq.each do |resource|
+        list_a = list_for_resource(resource)
+        list_b = other_map.list_for_resource(resource)
+        result[resource] = if list_a.nil?
+                             list_b
+                           elsif list_b.nil?
+                             list_a
+                           else
+                             list_a + list_b
+                           end
+      end
+
+      ResourceMap.new(result).condense
+    end
+
+    def -(other_map)
+      result = {}
+      other_wildcard = other_map.list_for_resource(WILDCARD_KEY) || PrxAuth::ScopeList.new('')
+
+      resources.each do |resource|
+        result[resource] = list_for_resource(resource) - (other_wildcard + other_map.list_for_resource(resource))
+      end
+
+      if @wildcard
+        result[WILDCARD_KEY] = @wildcard - other_wildcard
+      end
+
+      ResourceMap.new(result)
+    end
+
+    def &(other_map)
+      result = {}
+      other_wildcard = other_map.list_for_resource(WILDCARD_KEY)
+      
+      (resources + other_map.resources).uniq.each do |res|
+        left = list_for_resource(res)
+        right = other_map.list_for_resource(res)
+
+        result[res] = if left.nil?
+                        right & @wildcard
+                      elsif right.nil?
+                        left & other_wildcard
+                      else
+                        (left + @wildcard) & (right + other_wildcard)
+                      end
+      end
+
+      if @wildcard
+        result[WILDCARD_KEY] = @wildcard - (@wildcard - other_wildcard)
+      end
+
+      ResourceMap.new(result).condense
+    end
+
     def as_json(opts={})
       @map.merge(WILDCARD_KEY => @wildcard).as_json(opts)
     end
@@ -56,6 +112,13 @@ module PrxAuth
           list.contains?(namespace, scope) || @wildcard.contains?(namespace, scope)
         end.map(&:first)
       end
+    end
+
+    protected
+
+    def list_for_resource(resource)
+      return @wildcard if resource.to_s == WILDCARD_KEY
+      @map[resource.to_s]
     end
   end
 end

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -30,6 +30,18 @@ module PrxAuth
       end
     end
 
+    def condense
+      condensed_wildcard = @wildcard.condense
+      condensed_map = Hash[@map.map do |resource, list|
+        [resource, (list - condensed_wildcard).condense]
+      end]
+      ResourceMap.new(condensed_map.merge(WILDCARD_KEY => condensed_wildcard))
+    end
+
+    def as_json(opts={})
+      @map.merge(WILDCARD_KEY => @wildcard).as_json(opts)
+    end
+
     def freeze
       @map.freeze
       @wildcard.freeze

--- a/lib/prx_auth/resource_map.rb
+++ b/lib/prx_auth/resource_map.rb
@@ -53,7 +53,7 @@ module PrxAuth
         @map.keys
       else
         @map.select do |name, list|
-          list.contains?(namespace, scope)
+          list.contains?(namespace, scope) || @wildcard.contains?(namespace, scope)
         end.map(&:first)
       end
     end

--- a/lib/prx_auth/scope_list.rb
+++ b/lib/prx_auth/scope_list.rb
@@ -4,6 +4,13 @@ module PrxAuth
     NAMESPACE_SEPARATOR = ':'
     NO_NAMESPACE = :_
 
+    def self.new(list)
+      case list
+      when PrxAuth::ScopeList then list
+      else super(list)
+      end
+    end
+
     def initialize(list)
       @string = list
     end
@@ -55,6 +62,8 @@ module PrxAuth
     end
 
     def -(other_scope_list)
+      return self if other_scope_list.nil?
+
       tripped = false
       result = []
 
@@ -73,6 +82,18 @@ module PrxAuth
       else
         self
       end
+    end
+
+    def +(other_list)
+      return self if other_list.nil?
+
+      ScopeList.new([to_s, other_list.to_s].join(SCOPE_SEPARATOR)).condense
+    end
+
+    def &(other_list)
+      return ScopeList.new('') if other_list.nil?
+      
+      self - (self - other_list)
     end
 
     private

--- a/lib/rack/prx_auth/version.rb
+++ b/lib/rack/prx_auth/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class PrxAuth
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -95,4 +95,13 @@ describe PrxAuth::ResourceMap do
       assert !resources.include?('456')
     end
   end
+
+  describe '#condense' do
+    let (:input) {{ "one" => "one two three ns1:one", "two" => "two three", "*" => "two" }}
+    let (:json) { map.condense.as_json }
+
+    it "removes redundant values which are in the wildcard" do
+      assert !json["one"].include?("two")
+    end
+  end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -123,7 +123,7 @@ describe PrxAuth::ResourceMap do
   end
 
   describe '#-' do
-    it 'sutracts values' do
+    it 'subtracts values' do
       map = new_map("one" => "two three", "two" => "four") - new_map("one" => "three four")
       assert map.contains?('one', :two)
       assert map.contains?('two', :four)

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -97,11 +97,15 @@ describe PrxAuth::ResourceMap do
   end
 
   describe '#condense' do
-    let (:input) {{ "one" => "one two three ns1:one", "two" => "two three", "*" => "two" }}
+    let (:input) {{ "one" => "one two three ns1:one", "two" => "two three",  "three" => "two", "*" => "two" }}
     let (:json) { map.condense.as_json }
 
     it "removes redundant values which are in the wildcard" do
       assert !json["one"].include?("two")
+    end
+
+    it "keeps resources in the hash even if all scopes are redundant" do
+      assert json["three"] == ""
     end
   end
 end

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -137,10 +137,14 @@ describe PrxAuth::ResourceMap do
 
   describe '#&' do
     it 'computes the intersection' do
-      map = new_map("one" => "two three", "four" => "five six") & new_map("one" => "three four", "four" => "six seven")
+      map = (
+        new_map("one" => "two three", "four" => "five six", "five" => "five") &
+        new_map("one" => "three four", "four" => "six seven", "six" => "six")
+      )
       assert map.contains?("one", :three) && map.contains?("four", :six)
       assert !map.contains?("one", :two) && !map.contains?("four", :five)
       assert !map.contains?("one", :four) && !map.contains?("four", :seven)
+      assert !map.contains?("five", :five) && !map.contains?("six", :six)
     end
 
     it 'works with wildcards' do

--- a/test/prx_auth/resource_map_test.rb
+++ b/test/prx_auth/resource_map_test.rb
@@ -116,8 +116,9 @@ describe PrxAuth::ResourceMap do
 
   describe '#+' do
     it 'adds values' do
-      map = new_map("one" => "two") + new_map("one" => "three")
+      map = new_map("one" => "two", "two" => "four") + new_map("one" => "three", "three" => "six")
       assert map.contains?('one', :two) && map.contains?('one', :three)
+      assert map.contains?('two', :four) && map.contains?('three', :six)
     end
   end
 

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -41,4 +41,11 @@ describe PrxAuth::ScopeList do
     end
   end
 
+  describe '#condense' do
+    let (:scopes) { "ns1:foo foo" }
+    it 'removes redundant scopes based on namespace wildcards' do
+      assert list.condense.to_s == "foo"
+    end
+  end
+
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 describe PrxAuth::ScopeList do
+
+  def new_list(val)
+    PrxAuth::ScopeList.new(val)
+  end
+
   let (:scopes) { 'read write sell  top-up' }
   let (:list) { PrxAuth::ScopeList.new(scopes) }
 
@@ -48,4 +53,50 @@ describe PrxAuth::ScopeList do
     end
   end
 
+  describe '#-' do
+    it 'subtracts scopes' do
+      sl = new_list('one two') - new_list('two')
+      assert sl.kind_of? PrxAuth::ScopeList
+      assert !sl.contains?(:two)
+      assert sl.contains?(:one)
+    end
+
+    it 'works with scope wildcards' do
+      sl = new_list('ns1:one ns2:two') - new_list('one')
+      assert !sl.contains?(:ns1, :one)
+    end
+
+    it 'accepts nil' do
+      sl = new_list('one two') - nil
+      assert sl.contains?(:one) && sl.contains?(:two)
+    end
+  end
+
+  describe '#+' do
+    it 'adds scopes' do
+      sl = new_list('one') + new_list('two')
+      assert sl.kind_of? PrxAuth::ScopeList
+      assert sl.contains?(:one)
+      assert sl.contains?(:two)
+    end
+
+    it 'accepts nil' do
+      sl = new_list('one two') + nil
+      assert sl.contains?(:one) && sl.contains?(:two)
+    end
+  end
+
+  describe '#&' do
+    it 'gets the intersect of scopes' do
+      sl = (new_list('one two three four') & new_list('two four six'))
+      assert sl.kind_of? PrxAuth::ScopeList
+      assert sl.contains?(:two) && sl.contains?(:four)
+      assert !sl.contains?(:one) && !sl.contains?(:three)  && !sl.contains?(:six)
+    end
+
+    it 'accepts nil' do
+      sl = new_list('one') & nil
+      assert !sl.contains?(:one)
+    end
+  end
 end

--- a/test/prx_auth/scope_list_test.rb
+++ b/test/prx_auth/scope_list_test.rb
@@ -47,9 +47,9 @@ describe PrxAuth::ScopeList do
   end
 
   describe '#condense' do
-    let (:scopes) { "ns1:foo foo" }
+    let (:scopes) { "ns1:foo foo ns1:bar" }
     it 'removes redundant scopes based on namespace wildcards' do
-      assert list.condense.to_s == "foo"
+      assert list.condense.to_s == "foo ns1:bar"
     end
   end
 


### PR DESCRIPTION
I found myself needing some basic arithmetic (mostly, the intersect `&` operator) in id and started to implement there but thought it was better to do so here. Because of wildcard semantics it wound up being a little more complicated than it seems like it should be - especially ResourceMap#&

Luckily, because we don't have any way to do expansion in either case this can be mathematically correct. Subtracting non-wildcard values from a wildcard does mean that subtraction is not always technically complete, but this works fine for our purposes.